### PR TITLE
Lower required macOS version to 10.15 Catalina

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "NumericText",
-    platforms: [.iOS(.v14), .macOS(.v11), .watchOS(.v7), .tvOS(.v14)],
+    platforms: [.iOS(.v14), .macOS(.v10_15), .watchOS(.v7), .tvOS(.v14)],
     products: [
         .library(
             name: "NumericText",


### PR DESCRIPTION
There's currently no real reason to limit this package to Big Sur since Catalina does support all APIs used within this Package.

**EDIT**

Didn't notice that there are usages of `onChange`, so I closed this pull request.