### PR TITLE
Lower deployment target versions to iOS 13, macOS 10.15, watchOS 6 and tvOS 13

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ playground.xcworkspace
 
 .build/
 
+*.xcodeproj

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "NumericText",
-    platforms: [.iOS(.v14), .macOS(.v11), .watchOS(.v7), .tvOS(.v14)],
+    platforms: [.iOS(.v13), .macOS(.v10_15), .watchOS(.v6), .tvOS(.v13)],
     products: [
         .library(
             name: "NumericText",

--- a/Sources/NumericText/ChangeObserver.swift
+++ b/Sources/NumericText/ChangeObserver.swift
@@ -1,0 +1,70 @@
+import Foundation
+import SwiftUI
+import Combine
+
+/// See `View.onChange(of: value, perform: action)` for more information
+struct ChangeObserver<Base: View, Value: Equatable>: View {
+    let base: Base
+    let value: Value
+    let action: (Value)->Void
+    
+    let model = Model()
+    
+    var body: some View {
+        if model.update(value: value) {
+            DispatchQueue.main.async { self.action(self.value) }
+        }
+        return base
+    }
+    
+    class Model {
+        private var savedValue: Value?
+        func update(value: Value) -> Bool {
+            guard value != savedValue else { return false }
+            savedValue = value
+            return true
+        }
+    }
+}
+
+extension View {
+    /// Adds a modifier for this view that fires an action when a specific value changes.
+    ///
+    /// You can use `onChange` to trigger a side effect as the result of a value changing, such as an Environment key or a Binding.
+    ///
+    /// `onChange` is called on the main thread. Avoid performing long-running tasks on the main thread. If you need to perform a long-running task in response to value changing, you should dispatch to a background queue.
+    ///
+    /// The new value is passed into the closure. The previous value may be captured by the closure to compare it to the new value. For example, in the following code example, PlayerView passes both the old and new values to the model.
+    ///
+    /// ```
+    /// struct PlayerView : View {
+    ///   var episode: Episode
+    ///   @State private var playState: PlayState
+    ///
+    ///   var body: some View {
+    ///     VStack {
+    ///       Text(episode.title)
+    ///       Text(episode.showTitle)
+    ///       PlayButton(playState: $playState)
+    ///     }
+    ///   }
+    ///   .onChange(of: playState) { [playState] newState in
+    ///     model.playStateDidChange(from: playState, to: newState)
+    ///   }
+    /// }
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - value: The value to check against when determining whether to run the closure.
+    ///   - action: A closure to run when the value changes.
+    ///   - newValue: The new value that failed the comparison check.
+    /// - Returns: A modified version of this view
+    func onChangeShimmed<Value: Equatable>(
+        of value: Value,
+        perform action: @escaping (_ newValue: Value)->Void) -> some View {
+        if #available(iOS 14.0, macOS 11, tvOS 14.0, watchOS 7.0, *) {
+            return AnyView(self.onChange(of: value, perform: action))
+        }
+        return AnyView(ChangeObserver(base: self, value: value, action: action))
+    }
+}

--- a/Sources/NumericText/NumericTextModifier.swift
+++ b/Sources/NumericText/NumericTextModifier.swift
@@ -9,7 +9,7 @@ public struct NumericTextModifier: ViewModifier {
     @Binding public var text: String
     /// A number that will be updated when the `text` is updated.
     @Binding public var number: NSNumber?
-
+        
     /// A modifier that observes any changes to a string, and updates that string to remove any non-numeric characters.
     /// It also will convert that string to a `NSNumber` for easy use.
     ///
@@ -24,15 +24,15 @@ public struct NumericTextModifier: ViewModifier {
     }
 
     public func body(content: Content) -> some View {
-        content
-            .onChange(of: text) { newValue in
+        return content
+            .onChangeShimmed(of: text) { newValue in
                 let numeric = newValue.numericValue(allowDecimalSeparator: isDecimalAllowed)
                 if newValue != numeric {
                     text = numeric
                 }
                 number = decimalNumberFormatter.number(from: numeric)
             }
-            .onChange(of: number, perform: { newValue in
+            .onChangeShimmed(of: number, perform: { newValue in
                 if let number = newValue {
                     text = decimalNumberFormatter.string(from: number) ?? ""
                 } else {

--- a/Tests/NumericTextTests/StringNumericTests.swift
+++ b/Tests/NumericTextTests/StringNumericTests.swift
@@ -2,10 +2,12 @@ import NumericText
 import XCTest
 
 final class StringNumericTests: XCTestCase {
+    let s = Locale.current.decimalSeparator ?? "."
+    
     func testDoubleDecimal() {
-        XCTAssertEqual("12.3.4".numericValue(allowDecimalSeparator: true), "12.34")
-        XCTAssertEqual("12..34".numericValue(allowDecimalSeparator: true), "12.34")
-        XCTAssertEqual(".1234.".numericValue(allowDecimalSeparator: true), ".1234")
+        XCTAssertEqual("12\(s)3\(s)4".numericValue(allowDecimalSeparator: true), "12\(s)34")
+        XCTAssertEqual("12\(s)34".numericValue(allowDecimalSeparator: true), "12\(s)34")
+        XCTAssertEqual("\(s)1234\(s)".numericValue(allowDecimalSeparator: true), "\(s)1234")
     }
 
     func testObscureNumericCharacters() throws {
@@ -20,8 +22,8 @@ final class StringNumericTests: XCTestCase {
     }
 
     func testAlphaNumeric() {
-        XCTAssertEqual("12a.3b4".numericValue(allowDecimalSeparator: true), "12.34")
+        XCTAssertEqual("12a\(s)3b4".numericValue(allowDecimalSeparator: true), "12\(s)34")
         XCTAssertEqual("12abc34".numericValue(allowDecimalSeparator: true), "1234")
-        XCTAssertEqual("a.1234.".numericValue(allowDecimalSeparator: true), ".1234")
+        XCTAssertEqual("a\(s)1234\(s)".numericValue(allowDecimalSeparator: true), "\(s)1234")
     }
 }


### PR DESCRIPTION
Using a shim, we can lower the required deployment target versions to iOS 13, macOS 10.15, watchOS 6 and tvOS 13.

This pull request also fixes tests by using the localized decimal seperator for the executing environment.