### PR TITLE
Support for custom NumberFormatters

### DIFF
--- a/Sources/NumericText/NumericTextField.swift
+++ b/Sources/NumericText/NumericTextField.swift
@@ -7,7 +7,7 @@ public struct NumericTextField: View {
     @Binding private var number: NSNumber?
     @State private var string: String
     private let isDecimalAllowed: Bool
-    private let numberFormatter: NumberFormatter?
+    private let numberFormatter: NumberFormatter
 
     private let title: LocalizedStringKey
     private let onEditingChanged: (Bool) -> Void
@@ -31,14 +31,16 @@ public struct NumericTextField: View {
                 onCommit: @escaping () -> Void = {}
     ) {
         _number = number
-        if let number = number.wrappedValue, let string = decimalNumberFormatter.string(from: number) {
+        
+        self.numberFormatter = numberFormatter ?? decimalNumberFormatter
+        
+        if let number = number.wrappedValue, let string = self.numberFormatter.string(from: number) {
             _string = State(initialValue: string)
         } else {
             _string = State(initialValue: "")
         }
         
         self.isDecimalAllowed = isDecimalAllowed
-        self.numberFormatter = numberFormatter
         
         title = titleKey
         self.onEditingChanged = onEditingChanged

--- a/Sources/NumericText/NumericTextField.swift
+++ b/Sources/NumericText/NumericTextField.swift
@@ -7,6 +7,7 @@ public struct NumericTextField: View {
     @Binding private var number: NSNumber?
     @State private var string: String
     private let isDecimalAllowed: Bool
+    private let numberFormatter: NumberFormatter?
 
     private let title: LocalizedStringKey
     private let onEditingChanged: (Bool) -> Void
@@ -22,14 +23,23 @@ public struct NumericTextField: View {
     ///   - onEditingChanged: An action thats called when the user begins editing `text` and after the user finishes editing `text`.
     ///     The closure receives a Boolean indicating whether the text field is currently being edited.
     ///   - onCommit: An action to perform when the user performs an action (for example, when the user hits the return key) while the text field has focus.
-    public init(_ titleKey: LocalizedStringKey, number: Binding<NSNumber?>, isDecimalAllowed: Bool, onEditingChanged: @escaping (Bool) -> Void = { _ in }, onCommit: @escaping () -> Void = {}) {
+    public init(_ titleKey: LocalizedStringKey,
+                number: Binding<NSNumber?>,
+                isDecimalAllowed: Bool,
+                numberFormatter: NumberFormatter? = nil,
+                onEditingChanged: @escaping (Bool) -> Void = { _ in },
+                onCommit: @escaping () -> Void = {}
+    ) {
         _number = number
         if let number = number.wrappedValue, let string = decimalNumberFormatter.string(from: number) {
             _string = State(initialValue: string)
         } else {
             _string = State(initialValue: "")
         }
+        
         self.isDecimalAllowed = isDecimalAllowed
+        self.numberFormatter = numberFormatter
+        
         title = titleKey
         self.onEditingChanged = onEditingChanged
         self.onCommit = onCommit

--- a/Sources/NumericText/NumericTextField.swift
+++ b/Sources/NumericText/NumericTextField.swift
@@ -47,7 +47,7 @@ public struct NumericTextField: View {
 
     public var body: some View {
         TextField(title, text: $string, onEditingChanged: onEditingChanged, onCommit: onCommit)
-            .numericText(text: $string, number: $number, isDecimalAllowed: isDecimalAllowed)
+            .numericText(text: $string, number: $number, isDecimalAllowed: isDecimalAllowed, numberFormatter: numberFormatter)
             .modifier(KeyboardModifier(isDecimalAllowed: isDecimalAllowed))
     }
 }

--- a/Sources/NumericText/NumericTextField.swift
+++ b/Sources/NumericText/NumericTextField.swift
@@ -20,6 +20,7 @@ public struct NumericTextField: View {
     ///     describing its purpose.
     ///   - number: The number to be displayed and edited.
     ///   - isDecimalAllowed: Should the user be allowed to enter a decimal number, or an integer
+    ///   - numberFormatter: Custom number formatter used for formatting number in view
     ///   - onEditingChanged: An action thats called when the user begins editing `text` and after the user finishes editing `text`.
     ///     The closure receives a Boolean indicating whether the text field is currently being edited.
     ///   - onCommit: An action to perform when the user performs an action (for example, when the user hits the return key) while the text field has focus.
@@ -33,14 +34,13 @@ public struct NumericTextField: View {
         _number = number
         
         self.numberFormatter = numberFormatter ?? decimalNumberFormatter
+        self.isDecimalAllowed = isDecimalAllowed
         
         if let number = number.wrappedValue, let string = self.numberFormatter.string(from: number) {
             _string = State(initialValue: string)
         } else {
             _string = State(initialValue: "")
         }
-        
-        self.isDecimalAllowed = isDecimalAllowed
         
         title = titleKey
         self.onEditingChanged = onEditingChanged

--- a/Sources/NumericText/NumericTextModifier.swift
+++ b/Sources/NumericText/NumericTextModifier.swift
@@ -19,6 +19,7 @@ public struct NumericTextModifier: ViewModifier {
     ///   - text: The string that this should observe and filter
     ///   - number: A number that should be updated whenever the `text` is updated
     ///   - isDecimalAllowed: Should the user be allowed to enter a decimal number, or an integer
+    ///   - numberFormatter: Custom number formatter used for formatting number in view
     public init(text: Binding<String>, number: Binding<NSNumber?>, isDecimalAllowed: Bool, numberFormatter: NumberFormatter? = nil) {
         _text = text
         _number = number

--- a/Sources/NumericText/NumericTextModifier.swift
+++ b/Sources/NumericText/NumericTextModifier.swift
@@ -48,7 +48,7 @@ public struct NumericTextModifier: ViewModifier {
 public extension View {
     /// A modifier that observes any changes to a string, and updates that string to remove any non-numeric characters.
     /// It also will convert that string to a `NSNumber` for easy use.
-    func numericText(text: Binding<String>, number: Binding<NSNumber?>, isDecimalAllowed: Bool) -> some View {
-        modifier(NumericTextModifier(text: text, number: number, isDecimalAllowed: isDecimalAllowed))
+    func numericText(text: Binding<String>, number: Binding<NSNumber?>, isDecimalAllowed: Bool, numberFormatter: NumberFormatter?) -> some View {
+        modifier(NumericTextModifier(text: text, number: number, isDecimalAllowed: isDecimalAllowed, numberFormatter: numberFormatter))
     }
 }

--- a/Sources/NumericText/NumericTextModifier.swift
+++ b/Sources/NumericText/NumericTextModifier.swift
@@ -5,6 +5,8 @@ import SwiftUI
 public struct NumericTextModifier: ViewModifier {
     /// Should the user be allowed to enter a decimal number, or an integer
     public let isDecimalAllowed: Bool
+    /// Number formatter used to format numer in view
+    public let numberFormatter: NumberFormatter
     /// The string that the text field is bound to
     @Binding public var text: String
     /// A number that will be updated when the `text` is updated.
@@ -17,10 +19,11 @@ public struct NumericTextModifier: ViewModifier {
     ///   - text: The string that this should observe and filter
     ///   - number: A number that should be updated whenever the `text` is updated
     ///   - isDecimalAllowed: Should the user be allowed to enter a decimal number, or an integer
-    public init(text: Binding<String>, number: Binding<NSNumber?>, isDecimalAllowed: Bool) {
+    public init(text: Binding<String>, number: Binding<NSNumber?>, isDecimalAllowed: Bool, numberFormatter: NumberFormatter? = nil) {
         _text = text
         _number = number
         self.isDecimalAllowed = isDecimalAllowed
+        self.numberFormatter = numberFormatter ?? decimalNumberFormatter
     }
 
     public func body(content: Content) -> some View {
@@ -30,11 +33,11 @@ public struct NumericTextModifier: ViewModifier {
                 if newValue != numeric {
                     text = numeric
                 }
-                number = decimalNumberFormatter.number(from: numeric)
+                number = numberFormatter.number(from: numeric)
             }
             .onChangeShimmed(of: number, perform: { newValue in
                 if let number = newValue {
-                    text = decimalNumberFormatter.string(from: number) ?? ""
+                    text = numberFormatter.string(from: number) ?? ""
                 } else {
                     text = ""
                 }


### PR DESCRIPTION
Default `NumberFormatter` uses maximum 3 fraction digits. Sometimes it's not enough. Pull request gives possibility to pass custom `NumberFormatter` thus developer can define what he wants. For example:

```swift
struct SimpleView: View {
    @Binding private var amount: NSNumber?

    var body: some View {
        NumericTextField("Amount",
                         number: $amount,
                         isDecimalAllowed: true,
                         numberFormatter: NumberFormatter.amountFormatter)
            .multilineTextAlignment(.trailing)
    }
}

public extension NumberFormatter {
    static var amountFormatter: NumberFormatter = {
        let formatter = NumberFormatter()
                
        formatter.numberStyle = .decimal
        formatter.maximumFractionDigits = 10
    
        return formatter
    }()
}
```